### PR TITLE
added `mkdir -p`

### DIFF
--- a/client-setup/setup.sh
+++ b/client-setup/setup.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+mkdir -p ~/.aws
 touch ~/.aws/credentials
 cat << EOF >> ~/.aws/credentials
 [default]


### PR DESCRIPTION
when the directory does not exist, the script will fail to place the access tokens correctly